### PR TITLE
Refactor the email backend into a notifier concept

### DIFF
--- a/examples/user_checker.rb
+++ b/examples/user_checker.rb
@@ -21,8 +21,12 @@ CheckerJobs.configure do |config|
 
   config.jobs_processor = :sidekiq
 
-  config.emails_backend = :action_mailer
-  config.emails_options = { from: "oss@drivy.com", reply_to: "no-reply@drivy.com" }
+  config.notifier :email do |options|
+    options[:email_options] = {
+      from: "oss@drivy.com", reply_to: "no-reply@drivy.com"
+    }
+    options[:formatter_class] = CheckerJobs::Notifiers::EmailDefaultFormatter
+  end
 
   config.around_check = -> {
     puts "Starting check #{check.name}..."
@@ -40,7 +44,7 @@ class UserChecker
 
   options sidekiq: { queue: :fast }
 
-  notify "tech@drivy.com"
+  notify :email, to: "tech@drivy.com"
 
   ensure_no :inconsistent_payment do
     UserRepository.missing_email.size

--- a/lib/checker_jobs/checks/base.rb
+++ b/lib/checker_jobs/checks/base.rb
@@ -10,9 +10,8 @@ CheckerJobs::Checks::Base = Struct.new(:klass, :name, :options, :block) do
   private
 
   def notify(count:, entries: nil)
-    CheckerJobs.configuration.emails_backend_class.
-      new(self, count, entries).
-      notify
+    notifier_class = CheckerJobs.configuration.notifier_class(klass.notifier)
+    notifier_class.new(self, count, entries).notify
   end
 
   def handle_result(_result)

--- a/lib/checker_jobs/configuration.rb
+++ b/lib/checker_jobs/configuration.rb
@@ -4,21 +4,29 @@ require "checker_jobs/jobs_processors"
 class CheckerJobs::Configuration
   DEFAULT_TIME_BETWEEN_CHECKS = 15 * 60 # 15 minutes, expressed in seconds
 
+  NOTIFIER_CLASSES = {
+    email:          "CheckerJobs::Notifiers::Email",
+    logger:         "CheckerJobs::Notifiers::Logger",
+  }.freeze
+
   attr_accessor :jobs_processor,
-                :emails_backend,
-                :emails_options,
-                :emails_formatter_class,
+                :notifiers_options,
                 :time_between_checks,
                 :repository_url,
                 :around_check
 
   def self.default
     new.tap do |config|
-      config.emails_options = {}
-      config.emails_formatter_class = CheckerJobs::EmailsBackends::DefaultFormatter
+      config.notifiers_options = {}
       config.time_between_checks = DEFAULT_TIME_BETWEEN_CHECKS
       config.around_check = ->(&block) { block.call }
     end
+  end
+
+  def notifier(notifier_symbol)
+    options = {}
+    yield(options)
+    @notifiers_options[notifier_symbol] = options
   end
 
   def jobs_processor_module
@@ -30,12 +38,10 @@ class CheckerJobs::Configuration
     end
   end
 
-  def emails_backend_class
-    case emails_backend
-    when :action_mailer
-      CheckerJobs::EmailsBackends::ActionMailer
-    else
-      raise CheckerJobs::UnsupportedConfigurationOption.new(:emails_backend, emails_backend)
+  def notifier_class(notifier)
+    notifier_class_name = NOTIFIER_CLASSES.fetch(notifier) do
+      raise CheckerJobs::UnsupportedConfigurationOption.new(:notifier, notifier)
     end
+    Object.const_get(notifier_class_name)
   end
 end

--- a/lib/checker_jobs/dsl.rb
+++ b/lib/checker_jobs/dsl.rb
@@ -16,8 +16,9 @@ module CheckerJobs::DSL
     @options = options_hash
   end
 
-  def notify(target)
-    @notification_target = target
+  def notify(notifier, notifier_options = {})
+    @notifier = notifier
+    @notifier_options = notifier_options
   end
 
   def interval(duration)
@@ -40,10 +41,14 @@ module CheckerJobs::DSL
   # Private API
   #
 
-  def notification_target
-    raise CheckerJobs::MissingNotificationTarget, self.class unless defined?(@notification_target)
+  def notifier
+    raise CheckerJobs::MissingNotifier, self.class unless defined?(@notifier)
+    @notifier
+  end
 
-    @notification_target
+  def notifier_options
+    raise CheckerJobs::MissingNotifier, self.class unless defined?(@notifier)
+    @notifier_options
   end
 
   def time_between_checks

--- a/lib/checker_jobs/emails_backends.rb
+++ b/lib/checker_jobs/emails_backends.rb
@@ -1,4 +1,5 @@
-module CheckerJobs::EmailsBackends
-  autoload :ActionMailer,     "checker_jobs/emails_backends/action_mailer"
-  autoload :DefaultFormatter, "checker_jobs/emails_backends/default_formatter"
+module CheckerJobs::Notifiers
+  autoload :Email,                  "checker_jobs/notifiers/email"
+  autoload :EmailDefaultFormatter,  "checker_jobs/notifiers/email_default_formatter"
+  autoload :Logger,                 "checker_jobs/notifiers/logger"
 end

--- a/lib/checker_jobs/errors.rb
+++ b/lib/checker_jobs/errors.rb
@@ -2,7 +2,10 @@ module CheckerJobs
   class Error < StandardError
   end
 
-  class MissingNotificationTarget < Error
+  class MissingNotifier < Error
+  end
+
+  class InvalidNotifierOptions < Error
   end
 
   class Unconfigured < Error

--- a/lib/checker_jobs/notifiers/email_default_formatter.rb
+++ b/lib/checker_jobs/notifiers/email_default_formatter.rb
@@ -1,4 +1,4 @@
-class CheckerJobs::EmailsBackends::DefaultFormatter
+class CheckerJobs::Notifiers::EmailDefaultFormatter
   def initialize(check, count, entries)
     @check = check
     @count = count

--- a/lib/checker_jobs/notifiers/logger.rb
+++ b/lib/checker_jobs/notifiers/logger.rb
@@ -1,0 +1,51 @@
+require "logger"
+
+class CheckerJobs::Notifiers::Logger
+  DEFAULT_LEVEL = Logger::INFO
+  DEFAULT_LOGDEV = STDOUT
+
+  def initialize(check, count, entries)
+    @check = check
+    @count = count
+    @entries = entries
+    raise CheckerJobs::InvalidNotifierOptions unless valid?
+
+    @logger = Logger.new(logdev)
+    @logger.level = level
+  end
+
+  def notify
+    @logger.add(level, format, @check.name.tr("_", " ").capitalize)
+  end
+
+  # override this
+  def format
+    "found #{@count} entries"
+  end
+
+  private
+
+  def valid?
+    (logdev.is_a?(String) || logdev.is_a?(IO)) &&
+      [
+        Logger::UNKNOWN, Logger::FATAL, Logger::ERROR,
+        Logger::WARN, Logger::INFO, Logger::DEBUG
+      ].include?(level)
+  end
+
+  def level
+    @level ||=  @check.klass.notifier_options[:level] ||
+                notifier_options[:level] ||
+                DEFAULT_LEVEL
+  end
+
+  def logdev
+    @logdev ||= @check.klass.notifier_options[:logdev] ||
+                notifier_options[:logdev] ||
+                DEFAULT_LOGDEV
+  end
+
+  def notifier_options
+    CheckerJobs.configuration.notifiers_options[@check.klass.notifier]
+  end
+end

--- a/spec/checker_jobs/checks/base_spec.rb
+++ b/spec/checker_jobs/checks/base_spec.rb
@@ -4,14 +4,16 @@ RSpec.describe CheckerJobs::Checks::Base, :configuration do
   let(:checker_klass) do
     Class.new do
       include CheckerJobs::Base
-      notify "oss@drivy.com"
+      notify :email, to: "oss@drivy.com"
     end
   end
 
   describe "#perform" do
     subject(:perform) { instance.perform }
 
-    let(:block) { Proc.new { self.class.notification_target.length } }
+    let(:block) do
+      Proc.new { self.class.notifier_options[:to].length }
+    end
 
     it "executes the block in the context of a new klass's instance" do
       is_expected.to eq 13 # "oss@drivy.com".size

--- a/spec/checker_jobs/checks/ensure_fewer_spec.rb
+++ b/spec/checker_jobs/checks/ensure_fewer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CheckerJobs::Checks::EnsureFewer, :email, :configuration do
   let(:checker_klass) do
     Class.new do
       include CheckerJobs::Base
-      notify "oss@drivy.com"
+      notify :email, to: "oss@drivy.com"
     end
   end
 

--- a/spec/checker_jobs/checks/ensure_more_spec.rb
+++ b/spec/checker_jobs/checks/ensure_more_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CheckerJobs::Checks::EnsureMore, :email, :configuration do
   let(:checker_klass) do
     Class.new do
       include CheckerJobs::Base
-      notify "oss@drivy.com"
+      notify :email, to: "oss@drivy.com"
     end
   end
 

--- a/spec/checker_jobs/checks/ensure_no_spec.rb
+++ b/spec/checker_jobs/checks/ensure_no_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CheckerJobs::Checks::EnsureNo, :email, :configuration do
   let(:checker_klass) do
     Class.new do
       include CheckerJobs::Base
-      notify "oss@drivy.com"
+      notify :email, to: "oss@drivy.com"
     end
   end
 

--- a/spec/checker_jobs/configuration_spec.rb
+++ b/spec/checker_jobs/configuration_spec.rb
@@ -13,18 +13,6 @@ RSpec.describe CheckerJobs::Configuration do
       expect(default).not_to be other_default
     end
 
-    describe "the default emails_options value" do
-      subject(:emails_options) { default.emails_options }
-
-      it { is_expected.to eq({}) }
-    end
-
-    describe "the default emails_formatter_class value" do
-      subject(:emails_formatter_class) { default.emails_formatter_class }
-
-      it { is_expected.to eq CheckerJobs::EmailsBackends::DefaultFormatter }
-    end
-
     describe "the default time_between_checks value" do
       subject(:time_between_checks) { default.time_between_checks }
 
@@ -62,22 +50,18 @@ RSpec.describe CheckerJobs::Configuration do
     end
   end
 
-  describe "#emails_backend_class" do
-    subject(:emails_backend_class) { instance.emails_backend_class }
-
-    context "when emails_backend isn't supported (or unset)" do
-      before { instance.emails_backend = :mailer }
-
+  describe "#notifier_class" do
+    context "when notifier isn't supported (or unset)" do
       it do
-        expect { emails_backend_class }.
+        expect { instance.notifier_class(:test) }.
           to raise_error CheckerJobs::UnsupportedConfigurationOption
       end
     end
 
-    context "when emails_backend is set to :action_mailer" do
-      before { instance.emails_backend = :action_mailer }
-
-      it { is_expected.to be CheckerJobs::EmailsBackends::ActionMailer }
+    context "when notifier is set to :email" do
+      it do
+        expect(instance.notifier_class(:email)).to be(CheckerJobs::Notifiers::Email)
+      end
     end
   end
 end

--- a/spec/checker_jobs/dsl_spec.rb
+++ b/spec/checker_jobs/dsl_spec.rb
@@ -3,10 +3,15 @@ RSpec.describe CheckerJobs::DSL do
 
   let(:key) { Object.new }
   let(:block) { Proc.new {} }
-  let(:target) { Object.new }
+  let(:notifier) { :email }
+  let(:notifier_options) { { to: "tech@drivy.com", from: "checkers@drivy.com" } }
   let(:default) { Object.new }
   let(:options) { Object.new }
   let(:duration) { Object.new }
+
+  before do
+    CheckerJobs.configure {}
+  end
 
   #
   # Private API
@@ -24,19 +29,35 @@ RSpec.describe CheckerJobs::DSL do
     end
   end
 
-  describe "#notification_target" do
-    subject(:get_notification_target) { instance.notification_target }
+  describe "#notifier" do
+    subject(:get_notifier) { instance.notifier }
 
     context "without prior call to #notify" do
       it do
-        expect { get_notification_target }.to raise_error CheckerJobs::MissingNotificationTarget
+        expect { get_notifier }.to raise_error CheckerJobs::MissingNotifier
       end
     end
 
     context "with a prior call to #notify" do
-      before { instance.notify(target) }
+      before { instance.notify(notifier, notifier_options) }
 
-      it { is_expected.to be target }
+      it { is_expected.to be notifier }
+    end
+  end
+
+  describe "#notifier_options" do
+    subject(:get_notifier_options) { instance.notifier_options }
+
+    context "without prior call to #notify" do
+      it do
+        expect { get_notifier_options }.to raise_error CheckerJobs::MissingNotifier
+      end
+    end
+
+    context "with a prior call to #notify" do
+      before { instance.notify(:email, notifier_options) }
+
+      it { is_expected.to be notifier_options }
     end
   end
 
@@ -72,11 +93,11 @@ RSpec.describe CheckerJobs::DSL do
   end
 
   describe "#notify" do
-    subject(:set_notification_target) { instance.notify(target) }
+    subject(:set_notifier_options) { instance.notify(notifier, notifier_options) }
 
-    it "updates #notification_target" do
-      set_notification_target
-      expect(instance.notification_target).to be target
+    it "updates #notification_to" do
+      set_notifier_options
+      expect(instance.notifier_options).to be notifier_options
     end
   end
 

--- a/spec/checker_jobs/notifiers/email_spec.rb
+++ b/spec/checker_jobs/notifiers/email_spec.rb
@@ -1,0 +1,41 @@
+require "support/email_helpers"
+
+RSpec.describe CheckerJobs::Notifiers::Email, :configuration, :email do
+  include EmailHelpers
+
+  let(:instance) do
+    CheckerJobs::Checks::EnsureFewer.new(
+      checker_klass, "ensure_name", { than: 3 }, Proc.new { 5 }
+    )
+  end
+
+  let(:checker_klass) do
+    Class.new do
+      include CheckerJobs::Base
+      notify :email, to: "oss@drivy.com"
+    end
+  end
+
+  describe "with default" do
+    subject(:perform) { instance.perform }
+
+    it "sends an email" do
+      sends_an_email
+    end
+  end
+
+  describe "with wrong params" do
+    subject(:perform) { instance.perform }
+
+    let(:checker_klass) do
+      Class.new do
+        include CheckerJobs::Base
+        notify :email, to: 42
+      end
+    end
+
+    it "raises an exception" do
+      expect { perform }.to raise_error(CheckerJobs::InvalidNotifierOptions)
+    end
+  end
+end

--- a/spec/checker_jobs/notifiers/logger_spec.rb
+++ b/spec/checker_jobs/notifiers/logger_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe CheckerJobs::Notifiers::Logger, :configuration do
+  let(:instance) do
+    CheckerJobs::Checks::EnsureFewer.new(
+      checker_klass, "ensure_name", { than: 3 }, Proc.new { 5 }
+    )
+  end
+
+  let(:checker_klass) do
+    Class.new do
+      include CheckerJobs::Base
+      notify :logger
+    end
+  end
+
+  context "with default" do
+    it "logs" do
+      expect do
+        instance.perform
+      end.to output(/INFO -- Ensure name: found 5 entries/).to_stdout_from_any_process
+    end
+  end
+
+  context "with params" do
+    let(:checker_klass) do
+      Class.new do
+        include CheckerJobs::Base
+        notify :logger, level: Logger::FATAL, logdev: STDERR
+      end
+    end
+
+    it "logs" do
+      expect do
+        instance.perform
+      end.to output(/FATAL -- Ensure name: found 5 entries/).to_stderr_from_any_process
+    end
+  end
+
+  context "with invalid log level" do
+    let(:checker_klass) do
+      Class.new do
+        include CheckerJobs::Base
+        notify :logger, level: "Picard"
+      end
+    end
+
+    it "raises an exception" do
+      expect { instance.perform }.to raise_error(CheckerJobs::InvalidNotifierOptions)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,8 +28,19 @@ RSpec.configure do |config|
   config.before(:context, :configuration) do
     CheckerJobs.configure do |c|
       c.jobs_processor = :sidekiq
-      c.emails_backend = :action_mailer
-      c.emails_options = { from: "oss@drivy.com", reply_to: "no-reply@drivy.com" }
+
+      c.notifier :email do |options|
+        options[:email_options] = {
+          from: "oss@drivy.com", reply_to: "no-reply@drivy.com"
+        }
+        options[:formatter_class] = CheckerJobs::Notifiers::EmailDefaultFormatter
+      end
+
+      c.notifier :logger do |options|
+        options[:logdev] = STDOUT
+        options[:level] = Logger::INFO
+      end
+
       c.repository_url = { github: "drivy/checker_jobs" }
     end
   end


### PR DESCRIPTION
This is a POC to open the discussion about the concept of notifiers.
Today we have a simple abstraction to eventually change the email backend; ie go from action mailer to pony by example. But I'd like to go a little bit further with an abstraction for any kind of alerting.
Ideally it would support at least email and pagerduty (that would then do the routing to phone, sms, push, ...).

The idea is to configure the notifiers this way:

```ruby
CheckerJobs.configure do |c|
  c.jobs_processor = :sidekiq
  c.notifier :action_mailer do |options|
    options[:email_options] = {
      from: "oss@drivy.com", reply_to: "no-reply@drivy.com"
    }
    options[:formatter_class] = CheckerJobs::Notifiers::EmailDefaultFormatter
  end

  c.notifier :pagerduty do |options|
    options[:api_key] = "XXX"
  end

  c.notifier :log do |options|
    options[:logger] = Logger.new
  end
end
```

And to use them with:

```ruby
class UserChecker < CheckerJobs::Base
  options sidekiq: { queue: :fast }

  notify :action_mailer, target: { "tech@drivy.com" }

  ensure_no :user_without_email do
    UserRepository.missing_email.size
  end
end
```

Now each notifier needs to declare a `valid_notify_options?` methods to validate whether the notify method was called with the right parameters. In the case of `:action_mailer` it checks that a `target` param was passed. 

The tests passes but I commented a few that didn't make sense anymore and a lot more needs to be written. I wanted to validate the concept first.

Also I'm thinking of renaming `:action_mailer` to `email`.


