### PR TITLE
Support custom formatters for Bugsnag

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
 #
 # Disabled cops
 #

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ require "checker_jobs"
 CheckerJobs.configure do |c|
   c.jobs_processor = :sidekiq
 
+  c.notifier :bugsnag do |options|
+    options[:formatter_class] = CheckerJobs::Notifiers::BugsnagDefaultFormatter
+  end
+
   c.notifier :email do |options|
     options[:formatter_class] = CheckerJobs::Notifiers::EmailDefaultFormatter
     options[:email_options] = {
@@ -119,7 +123,7 @@ PRs are appreciated 🙏
 
 We support different kind of notifiers, as of today we have the following:
 
-- `:bugsnag`: uses `Bugsnag` to send notifications. It takes the global configuration.
+- `:bugsnag`: uses `Bugsnag` to send notifications. It takes the global Bugsnag configuration.
 - `:email`: uses `ActionMailer` to send emails. You can pass it any `ActionMailer` options.
 - `:logger`: Uses `Logger` to output inconsitencies in the log. Takes the following params:
   - `logdev`: The log device. This is a filename (String) or IO object (typically STDOUT, STDERR, or an open file).

--- a/checker_jobs.gemspec
+++ b/checker_jobs.gemspec
@@ -1,8 +1,8 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "checker_jobs/version"
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name          = "checker_jobs"
   spec.version       = CheckerJobs::VERSION
   spec.authors       = ["Drivy", "Nicolas Zermati"]

--- a/examples/user_checker.rb
+++ b/examples/user_checker.rb
@@ -21,6 +21,10 @@ CheckerJobs.configure do |config|
 
   config.jobs_processor = :sidekiq
 
+  config.notifier :bugsnag do |options|
+    options[:formatter_class] = CheckerJobs::Notifiers::EmailDefaultFormatter
+  end
+
   config.notifier :email do |options|
     options[:formatter_class] = CheckerJobs::Notifiers::EmailDefaultFormatter
     options[:email_options] = {

--- a/lib/checker_jobs/configuration.rb
+++ b/lib/checker_jobs/configuration.rb
@@ -25,8 +25,8 @@ class CheckerJobs::Configuration
   end
 
   def notifier(notifier_symbol)
-    options = {}
-    yield(options)
+    options = default_options_for(notifier_symbol)
+    yield options
     @notifiers_options[notifier_symbol] = options
   end
 
@@ -44,5 +44,12 @@ class CheckerJobs::Configuration
       raise CheckerJobs::UnsupportedConfigurationOption.new(:notifier, notifier)
     end
     Object.const_get(notifier_class_name)
+  end
+
+  private
+
+  def default_options_for(notifier_symbol)
+    klass = notifier_class(notifier_symbol)
+    klass.respond_to?(:default_options) ? klass.default_options : {}
   end
 end

--- a/lib/checker_jobs/dsl.rb
+++ b/lib/checker_jobs/dsl.rb
@@ -43,11 +43,13 @@ module CheckerJobs::DSL
 
   def notifier
     raise CheckerJobs::MissingNotifier, self.class unless defined?(@notifier)
+
     @notifier
   end
 
   def notifier_options
     raise CheckerJobs::MissingNotifier, self.class unless defined?(@notifier)
+
     @notifier_options
   end
 
@@ -60,7 +62,7 @@ module CheckerJobs::DSL
   end
 
   def checks
-    @check ||= {}
+    @checks ||= {}
   end
 
   def add_check(klass, name, options, block)

--- a/lib/checker_jobs/notifiers.rb
+++ b/lib/checker_jobs/notifiers.rb
@@ -1,7 +1,9 @@
 module CheckerJobs::Notifiers
-  autoload :Bugsnag,                "checker_jobs/notifiers/bugsnag"
-  autoload :Email,                  "checker_jobs/notifiers/email"
-  autoload :EmailDefaultFormatter,  "checker_jobs/notifiers/email_default_formatter"
-  autoload :FormatterHelpers,       "checker_jobs/notifiers/formatter_helpers"
-  autoload :Logger,                 "checker_jobs/notifiers/logger"
+  autoload :Base,                    "checker_jobs/notifiers/base"
+  autoload :Bugsnag,                 "checker_jobs/notifiers/bugsnag"
+  autoload :BugsnagDefaultFormatter, "checker_jobs/notifiers/bugsnag_default_formatter"
+  autoload :Email,                   "checker_jobs/notifiers/email"
+  autoload :EmailDefaultFormatter,   "checker_jobs/notifiers/email_default_formatter"
+  autoload :FormatterHelpers,        "checker_jobs/notifiers/formatter_helpers"
+  autoload :Logger,                  "checker_jobs/notifiers/logger"
 end

--- a/lib/checker_jobs/notifiers/base.rb
+++ b/lib/checker_jobs/notifiers/base.rb
@@ -1,0 +1,22 @@
+class CheckerJobs::Notifiers::Base
+  def initialize(check, _count, _entries)
+    @check = check
+  end
+
+  def notify
+    raise NotImplementedError
+  end
+
+  def self.default_options
+    raise NotImplementedError
+  end
+
+  private
+
+  def notifier_options
+    CheckerJobs.configuration.notifiers_options.fetch(
+      @check.klass.notifier,
+      self.class.default_options,
+    )
+  end
+end

--- a/lib/checker_jobs/notifiers/bugsnag_default_formatter.rb
+++ b/lib/checker_jobs/notifiers/bugsnag_default_formatter.rb
@@ -1,0 +1,45 @@
+class CheckerJobs::Notifiers::BugsnagDefaultFormatter
+  include CheckerJobs::Notifiers::FormatterHelpers
+
+  def initialize(check, count, entries)
+    @check = check
+    @count = count
+    @entries = entries
+  end
+
+  def base_error
+    CheckerJobs::Notifiers::Bugsnag::Error.new(error_message)
+  end
+
+  def severity
+    "warning"
+  end
+
+  def context
+    "checker_jobs"
+  end
+
+  def grouping_hash
+    error_message
+  end
+
+  def tab_infos
+    ["triggered_check", triggered_check]
+  end
+
+  private
+
+  def triggered_check
+    {
+      klass: @check.klass,
+      name: @check.name,
+      count: @count,
+      entries: @entries&.map { |entry| format_entry(entry) },
+      source_code_url: repository_url,
+    }
+  end
+
+  def error_message
+    "(#{@check.klass}) #{human_check_name} was triggered!"
+  end
+end

--- a/lib/checker_jobs/notifiers/logger.rb
+++ b/lib/checker_jobs/notifiers/logger.rb
@@ -1,13 +1,11 @@
 require "logger"
 
-class CheckerJobs::Notifiers::Logger
+class CheckerJobs::Notifiers::Logger < CheckerJobs::Notifiers::Base
   include CheckerJobs::Notifiers::FormatterHelpers
 
-  DEFAULT_LEVEL = Logger::INFO
-  DEFAULT_LOGDEV = STDOUT
-
   def initialize(check, count, _entries)
-    @check = check
+    super
+
     @count = count
     raise CheckerJobs::InvalidNotifierOptions unless valid?
 
@@ -19,12 +17,19 @@ class CheckerJobs::Notifiers::Logger
     @logger.add(level, format, human_check_name)
   end
 
+  def self.default_options
+    {
+      logdev: STDOUT,
+      level: Logger::INFO,
+    }
+  end
+
+  private
+
   # override this
   def format
     "found #{@count} entries"
   end
-
-  private
 
   def valid?
     (logdev.is_a?(String) || logdev.is_a?(IO)) &&
@@ -35,18 +40,10 @@ class CheckerJobs::Notifiers::Logger
   end
 
   def level
-    @level ||=  @check.klass.notifier_options[:level] ||
-                notifier_options[:level] ||
-                DEFAULT_LEVEL
+    @level ||= @check.klass.notifier_options[:level] || notifier_options[:level]
   end
 
   def logdev
-    @logdev ||= @check.klass.notifier_options[:logdev] ||
-                notifier_options[:logdev] ||
-                DEFAULT_LOGDEV
-  end
-
-  def notifier_options
-    CheckerJobs.configuration.notifiers_options[@check.klass.notifier]
+    @logdev ||= @check.klass.notifier_options[:logdev] || notifier_options[:logdev]
   end
 end

--- a/spec/checker_jobs/checks/base_spec.rb
+++ b/spec/checker_jobs/checks/base_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CheckerJobs::Checks::Base, :configuration do
     end
 
     it "executes the block in the context of a new klass's instance" do
-      is_expected.to eq 13 # "oss@drivy.com".size
+      expect(perform).to eq 13 # "oss@drivy.com".size
     end
 
     context "when there is an around_check" do
@@ -33,7 +33,7 @@ RSpec.describe CheckerJobs::Checks::Base, :configuration do
       end
 
       it "delegates the execution of the block to the around_check" do
-        is_expected.to be 0
+        expect(perform).to be 0
       end
 
       it "keeps handling the result outside the around_check delegation" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,10 +9,16 @@ require "sidekiq"
 require "sidekiq/testing"
 
 ActionMailer::Base.delivery_method = :test
+
 Sidekiq::Testing.inline!
 
-# See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-RSpec.configure do |config|
+Bugsnag.configure do |config|
+  # This API key is completely fake, it shouldn't be used.
+  config.api_key = "11111111111111111111111111111111"
+  config.release_stage = "production"
+end
+
+RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
It also refactor the way default config a provided by the notifier classes. I allow to get a option's Hash filled with the default during the configuration step:

``` ruby
config.notifier :bugsnag do |options|
  # Here options[:formatter_class] is set to the default
end
```

It also refactor the way we call Bugsnag in order to use a compatible syntax with Bugsnag 6 reports (rather than notifications). The tests are updated in that direction in order to avoid Bugsnag 6 to pass the tests as it does today in #11.

Since rubocop was updated, some new offenses has been fixed.