### PR TITLE
Add support for booleans in handle_no

### DIFF
--- a/lib/checker_jobs/checks/ensure_no.rb
+++ b/lib/checker_jobs/checks/ensure_no.rb
@@ -7,6 +7,8 @@ class CheckerJobs::Checks::EnsureNo < CheckerJobs::Checks::Base
       notify(count: result) unless result.zero?
     when Enumerable
       notify(count: result.size, entries: result) unless result.empty?
+    when TrueClass, FalseClass
+      notify(count: 1) if result
     else
       raise ArgumentError, "Unsupported result: '#{result.class.name}' for 'ensure_no'"
     end

--- a/spec/checker_jobs/checks/ensure_no_spec.rb
+++ b/spec/checker_jobs/checks/ensure_no_spec.rb
@@ -37,5 +37,17 @@ RSpec.describe CheckerJobs::Checks::EnsureNo, :email, :configuration do
 
       it { sends_an_email }
     end
+
+    context "when block's result is true" do
+      let(:block) { Proc.new { true } }
+
+      it { sends_an_email }
+    end
+
+    context "when block's result is false" do
+      let(:block) { Proc.new { false } }
+
+      it { doesn_t_send_any_email }
+    end
   end
 end


### PR DESCRIPTION
Not fond of the `count: 1` part, maybe `count:` should become optional ?